### PR TITLE
Fix the wrong order of macro and namespace.

### DIFF
--- a/project_acpc_server/net.h
+++ b/project_acpc_server/net.h
@@ -61,6 +61,7 @@ ssize_t getLine( ReadBuf *readBuf,
 		 int64_t timeoutMicros );
 
 
+} // namespace project_acpc_server
+
 #endif
 
-} // namespace project_acpc_server


### PR DESCRIPTION
Hi,
I found a problem in the file net.h. Please check it.